### PR TITLE
Security hardening for portfolio app

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,48 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "img-src 'self' data: blob:",
+      "font-src 'self' data:",
+      "style-src 'self' 'unsafe-inline'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "connect-src 'self'",
+      "upgrade-insecure-requests",
+    ].join("; "),
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()",
+  },
+];
+
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {

--- a/src/pages/api/hello.tsx
+++ b/src/pages/api/hello.tsx
@@ -1,5 +1,0 @@
-import { NextApiRequest, NextApiResponse } from "next";
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json({ message: "Hello World" });
-}

--- a/src/pages/api/resumepdf.tsx
+++ b/src/pages/api/resumepdf.tsx
@@ -1,31 +1,76 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
-const s3Url = process.env.NEXT_PUBLIC_S3_RESUME;
+const resumeUrl = process.env.S3_RESUME_URL ?? process.env.NEXT_PUBLIC_S3_RESUME;
+const MAX_RESUME_SIZE_BYTES = 10 * 1024 * 1024;
+
+const isAllowedResumeUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const setSecurityHeaders = (res: NextApiResponse) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+};
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  setSecurityHeaders(res);
+
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.setHeader("Allow", "GET, HEAD");
+    res.status(405).send("Method not allowed");
+    return;
+  }
+
   try {
-    if (!s3Url) {
-      res.status(500).send("S3 URL is not defined");
+    if (!resumeUrl || !isAllowedResumeUrl(resumeUrl)) {
+      res.status(500).send("Resume URL is not configured correctly");
       return;
     }
 
-    const response = await fetch(s3Url, { redirect: "manual" });
+    const response = await fetch(resumeUrl, { redirect: "error" });
 
     if (!response.ok) {
-      res.status(500).send("Error fetching resume");
+      res.status(502).send("Error fetching resume");
+      return;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("application/pdf")) {
+      res.status(502).send("Invalid resume content type");
+      return;
+    }
+
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && Number(contentLength) > MAX_RESUME_SIZE_BYTES) {
+      res.status(502).send("Resume file is too large");
       return;
     }
 
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader("Content-Disposition", 'inline; filename="resume.pdf"');
 
+    if (req.method === "HEAD") {
+      res.status(200).end();
+      return;
+    }
+
     const arrayBuffer = await response.arrayBuffer();
-    res.send(Buffer.from(arrayBuffer));
+    if (arrayBuffer.byteLength > MAX_RESUME_SIZE_BYTES) {
+      res.status(502).send("Resume file is too large");
+      return;
+    }
+
+    res.status(200).send(Buffer.from(arrayBuffer));
   } catch (error) {
     console.error("Error fetching resume:", error);
-    res.status(500).send("Error fetching resume");
+    res.status(502).send("Error fetching resume");
   }
 }


### PR DESCRIPTION
## Summary
- Add global HTTP security headers, including CSP, frame denial, MIME sniffing protection, referrer policy, and restricted browser permissions.
- Harden the `/api/resumepdf` proxy by requiring GET/HEAD, enforcing HTTPS upstream URLs, rejecting redirects, validating PDF content type, limiting file size, and avoiding public-only env usage via `S3_RESUME_URL`.
- Remove the unused sample `/api/hello` endpoint to reduce exposed attack surface.

## Notes
- The resume route still supports the existing `NEXT_PUBLIC_S3_RESUME` variable as a fallback for compatibility, but `S3_RESUME_URL` should be used going forward so the upstream storage URL is not exposed in the client bundle.
- I could not directly read the private Dependabot Security Alerts page through the connector, but this branch is based on the latest `main`, which already includes the recent Dependabot dependency bumps for `next`, `postcss`, and related transitive packages.

## Testing
- Not run locally; changes were applied through GitHub repository APIs.