### PR TITLE
Fix minimatch Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix"
   },
   "resolutions": {
-    "glob": "10.5.0"
+    "glob": "10.5.0",
+    "@eslint/config-array/minimatch": "3.1.3",
+    "@eslint/eslintrc/minimatch": "3.1.3",
+    "eslint/minimatch": "3.1.3",
+    "eslint-plugin-import/minimatch": "3.1.3",
+    "eslint-plugin-jsx-a11y/minimatch": "3.1.3",
+    "eslint-plugin-react/minimatch": "3.1.3",
+    "@typescript-eslint/typescript-estree/minimatch": "9.0.7",
+    "glob/minimatch": "9.0.7"
   }
 }


### PR DESCRIPTION
## Summary
- Add Yarn selective resolutions for the vulnerable `minimatch` transitive dependency paths reported by Dependabot.
- Pin `minimatch` 3.x consumers to `3.1.3`.
- Pin `minimatch` 9.x consumers to `9.0.7`.

## Notes
- Dependabot reports these alerts against `yarn.lock`. This PR updates the Yarn resolution policy so installs resolve to the patched versions.
- If the alerts do not close immediately, run `yarn install` locally or in CI and commit the regenerated `yarn.lock` so the lockfile entries move from `3.1.2` to `3.1.3` and from `9.0.5` to `9.0.7`.

## Testing
- Not run locally; this environment cannot access the npm registry to install dependencies or regenerate `yarn.lock`.