### PR TITLE
Fix PostCSS and Picomatch Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^9",
     "eslint-config-next": "^15",
     "husky": "^9.1.4",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   },
@@ -42,6 +42,12 @@
     "eslint-plugin-jsx-a11y/minimatch": "3.1.3",
     "eslint-plugin-react/minimatch": "3.1.3",
     "@typescript-eslint/typescript-estree/minimatch": "9.0.7",
-    "glob/minimatch": "9.0.7"
+    "glob/minimatch": "9.0.7",
+    "next/postcss": "8.5.10",
+    "postcss": "8.5.10",
+    "anymatch/picomatch": "2.3.2",
+    "micromatch/picomatch": "2.3.2",
+    "readdirp/picomatch": "2.3.2",
+    "tinyglobby/picomatch": "4.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- Raise the direct `postcss` dev dependency to `^8.5.10`.
- Add Yarn selective resolutions for Next's transitive `postcss` to `8.5.10`.
- Add Yarn selective resolutions for vulnerable `picomatch` 2.x consumers to `2.3.2`.
- Add Yarn selective resolution for vulnerable `picomatch` 4.x consumers to `4.0.4`.

## Alerts addressed
- PostCSS XSS via unescaped `</style>` in CSS stringify output: patched in `8.5.10`.
- Picomatch method injection in POSIX character classes: patched in `2.3.2` and `4.0.4`.

## Notes
- Dependabot reports these alerts against `yarn.lock`, so the lockfile should be regenerated with `yarn install` and committed if GitHub does not close the alerts from the resolution policy alone.
- The branch is based on the latest available main at creation time; if GitHub says it is behind, update the branch or merge main before merging.

## Testing
- Not run locally; this environment cannot access the npm registry to install dependencies or regenerate `yarn.lock`.