### PR TITLE
Bump js-yaml to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "tinyglobby/picomatch": "4.0.4",
     "cross-spawn": "7.0.6",
     "@babel/core": "7.29.6",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,10 +2527,10 @@ jiti@^1.21.7:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.2.0, js-yaml@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@4.3.0, js-yaml@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary
- update the `js-yaml` resolution from `4.2.0` to `4.3.0`
- regenerate `yarn.lock` so the transitive `js-yaml@^4.1.1` entry resolves to `4.3.0`

This covers the same dependency update as Dependabot PR #51, which is currently conflicted against `main`.

## Verification
- `yarn audit --groups dependencies devDependencies --level low` -> `0 vulnerabilities found`
- `yarn install --frozen-lockfile --ignore-engines`
- `yarn lint`
- `NEXT_PUBLIC_PROJECTS='[]' NEXT_PUBLIC_EXPERIENCE_DATA='[]' yarn build`